### PR TITLE
Add info about required version of Node to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@ Orianna Bot</h1>
 
 [![Discord](https://discordapp.com/api/guilds/249481856687407104/widget.png?style=shield)](https://discord.gg/bfxdsRC)
 
-
 This is the source code for the Discord bot and website portions that compromise [Orianna Bot](https://orianna.molenzwiebel.xyz). Note that Orianna Bot is not intended for self-hosting (although it is theoretically possible), so if you want Orianna Bot on your Discord server the easiest solution is to simply press the large button [here](https://orianna.molenzwiebel.xyz).
 
 # Components
@@ -11,7 +10,8 @@ This is the source code for the Discord bot and website portions that compromise
 This project consists of two components, creatively named frontend and backend. Frontend is a single-page app Vue.js application bundled by Webpack. Backend is both an express web server that powers the frontend, as well as an Eris Discord bot.
 
 ## Developing Frontend
-To get started with developing on frontend, you'll need to install dependencies. I recommend getting [yarn](https://yarnpkg.com), then simply running `yarn install` to install all dependencies.
+
+To get started with developing on frontend, you'll need to install dependencies. First of all [Node.js](https://nodejs.org) installed on your hardware should have version 10 or lower. In case if you already have Node.js installed and its version is higher than 10 [nvm](https://github.com/nvm-sh/nvm) is a good choice. Then I recommend to get [yarn](https://yarnpkg.com) and simply run `yarn install` to install all dependencies.
 
 `yarn watch` will start a hot-reloading webserver on `http://localhost:8081` which will automatically reflect your changes. Running `yarn bundle` will produce an optimized minified bundle that backend can find.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This project consists of two components, creatively named frontend and backend. 
 
 ## Developing Frontend
 
-To get started with developing on frontend, you'll need to install dependencies. First of all [Node.js](https://nodejs.org) installed on your hardware should have version 10 or lower. In case if you already have Node.js installed and its version is higher than 10 [nvm](https://github.com/nvm-sh/nvm) is a good choice. Then I recommend to get [yarn](https://yarnpkg.com) and simply run `yarn install` to install all dependencies.
+To get started with developing on frontend, you'll need to install dependencies. First of all you need to have [Node.js](https://nodejs.org) installed and it should have version 10 or lower. In case if you already have Node.js installed and its version is higher than 10 [nvm](https://github.com/nvm-sh/nvm) is a good choice to reconsider. Then I recommend to get [yarn](https://yarnpkg.com) and simply run `yarn install` to install all dependencies.
 
 `yarn watch` will start a hot-reloading webserver on `http://localhost:8081` which will automatically reflect your changes. Running `yarn bundle` will produce an optimized minified bundle that backend can find.
 


### PR DESCRIPTION
## Issue
While installing dependencies on `./frontend` I get errors (posted at the end). 

## Steps to investigate 
I tried to run `yarn` on Nodes: `v14`, `v12` and only on `v10` installing dependencies was successful. 

## Why?
I think that this info may be relevant in `README.md` for potential contributors.

## Error output
> I won't paste whole because it's too long. Ping me if needed.
```shell
Output:
node-pre-gyp info it worked if it ends with ok
node-pre-gyp info using node-pre-gyp@0.6.39
node-pre-gyp info using node@14.3.0 | darwin | x64
node-pre-gyp info check checked for \"/Users/robertgrzonka/Projects/OriannaBot/frontend/node_modules/fsevents/lib/binding/Release/node-v83-darwin-x64/fse.node\" (not found)
node-pre-gyp http GET https://fsevents-binaries.s3-us-west-2.amazonaws.com/v1.1.3/fse-v1.1.3-node-v83-darwin-x64.tar.gz
node-pre-gyp http 404 https://fsevents-binaries.s3-us-west-2.amazonaws.com/v1.1.3/fse-v1.1.3-node-v83-darwin-x64.tar.gz
node-pre-gyp ERR! Tried to download(404): https://fsevents-binaries.s3-us-west-2.amazonaws.com/v1.1.3/fse-v1.1.3-node-v83-darwin-x64.tar.gz 
node-pre-gyp ERR! Pre-built binaries not found for fsevents@1.1.3 and node@14.3.0 (node-v83 ABI, unknown) (falling back to source compile with node-gyp) 
node-pre-gyp http 404 status code downloading tarball https://fsevents-binaries.s3-us-west-2.amazonaws.com/v1.1.3/fse-v1.1.3-node-v83-darwin-x64.tar.gz 
node-pre-gyp ERR! Tried to download(undefined): https://fsevents-binaries.s3-us-west-2.amazonaws.com/v1.1.3/fse-v1.1.3-node-v83-darwin-x64.tar.gz 
node-pre-gyp ERR! Pre-built binaries not found for fsevents@1.1.3 and node@14.3.0 (node-v83 ABI, unknown) (falling back to source compile with node-gyp) 
node-pre-gyp http Connection closed while downloading tarball file 
gypgyp info it worked if it ends with ok
 info it worked if it ends with ok
gyp info using node-gyp@5.1.0
gyp gypinfo info using  node@14.3.0 | darwin | x64
```

> A lot lines of code later:
```shell
In file included from ../fsevents.cc:6:
../../nan/nan.h:839:18: warning: 'MakeCallback' is deprecated: Use MakeCallback(..., async_context) [-Wdeprecated-declarations]
In file included from     return node::MakeCallback(../fsevents.cc:6
                 ^
:
../../nan/nan.h:839:18: warning: 'MakeCallback' is deprecated: Use MakeCallback(..., async_context) [-Wdeprecated-declarations]
    return node::MakeCallback(
                 ^
/Users/robertgrzonka/Library/Caches/node-gyp/14.3.0/include/node/node.h:188:1: note: 'MakeCallback' has been explicitly marked deprecated here
NODE_DEPRECATED(\"Use MakeCallback(..., async_context)\",
/Users/robertgrzonka/Library/Caches/node-gyp/14.3.0/include/node/node.h:^
188:/Users/robertgrzonka/Library/Caches/node-gyp/14.3.0/include/node/node.h1::108:20: note: expanded from macro 'NODE_DEPRECATED'
 note: 'MakeCallback' has been explicitly marked deprecated here    __attribute__((deprecated(message))) declarator

                   ^
NODE_DEPRECATED(\"Use MakeCallback(..., async_context)\",
^
/Users/robertgrzonka/Library/Caches/node-gyp/14.3.0/include/node/node.h:108:20: note: expanded from macro 'NODE_DEPRECATED'
    __attribute__((deprecated(message))) declarator
                   ^
In file included from ../fsevents.cc:6:
../../nan/nan.h:854:18: warning: 'MakeCallback' is deprecated: Use MakeCallback(..., async_context) [-Wdeprecated-declarations]
    return node::MakeCallback(
                 ^In file included from ../fsevents.cc:6:

../../nan/nan.h:854:18:/Users/robertgrzonka/Library/Caches/node-gyp/14.3.0/include/node/node.h:181: warning: 1'MakeCallback' is deprecated: Use MakeCallback(..., async_context) [-Wdeprecated-declarations]
: note:     return node::MakeCallback(
                 ^
'MakeCallback' has been explicitly marked deprecated here
/Users/robertgrzonka/Library/Caches/node-gyp/14.3.0/include/node/node.h:181:1: note: 'MakeCallback' has been explicitly marked deprecated here
NODE_DEPRECATED(\"Use MakeCallback(..., async_context)\",
^
/Users/robertgrzonka/Library/Caches/node-gyp/14.3.0/include/node/node.h:108:20: NODE_DEPRECATED(\"Use MakeCallback(..., async_context)\",
note: expanded from macro 'NODE_DEPRECATED'^

/Users/robertgrzonka/Library/Caches/node-gyp/14.3.0/include/node/node.h:108:20: note: expanded from macro 'NODE_DEPRECATED'    __attribute__((deprecated(message))) declarator
```