### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/frontend/src/components/sidebar/sidebar.vue
+++ b/frontend/src/components/sidebar/sidebar.vue
@@ -83,7 +83,7 @@
                 return "https://github.com/molenzwiebel/OriannaBot/commit/" + GIT_COMMITHASH;
             },
             gitCommit() {
-                return GIT_COMMITHASH.substr(0, 7);
+                return GIT_COMMITHASH.slice(0, 7);
             },
             gitBranch() {
                 return GIT_BRANCH;

--- a/trans/languages/es-MX.yaml
+++ b/trans/languages/es-MX.yaml
@@ -1,6 +1,6 @@
 metadata:
   code: es-MX
-  name: Español (Mexico)
+  name: Español (México)
   ddragonLanguage: es_MX
 empty: ""
 ranked_tier_unranked: Sin clasificar


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.